### PR TITLE
Fix environment variable bug when detecting new clients

### DIFF
--- a/RuneFleet/MainForm.cs
+++ b/RuneFleet/MainForm.cs
@@ -404,8 +404,8 @@ namespace RuneFleet
                     {
                         var env = EnvReader.ReadEnvironmentVariablesFromProcess(proc.Id);
                         string sessionId = env.ContainsKey("JX_SESSION_ID") ? env["JX_SESSION_ID"] : null;
-                        string displayName = env.ContainsKey("JX_SESSION_ID") ? env["JX_DISPLAY_NAME"] : null;
-                        string characterId = env.ContainsKey("JX_SESSION_ID") ? env["JX_CHARACTER_ID"] : null;
+                        string displayName = env.ContainsKey("JX_DISPLAY_NAME") ? env["JX_DISPLAY_NAME"] : null;
+                        string characterId = env.ContainsKey("JX_CHARACTER_ID") ? env["JX_CHARACTER_ID"] : null;
                         string clientPath = proc.MainModule?.FileName ?? "";
 
                         if (!string.IsNullOrWhiteSpace(displayName) && !accounts.Any(a => a.DisplayName == displayName))


### PR DESCRIPTION
## Summary
- correct environment variable checks in `WatchForClientsAsync`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2238bb0c8323900f9e32722cc537