### PR TITLE
Refactor MainForm with AccountManager

### DIFF
--- a/RuneFleet.Tests/Services/AccountManagerTests.cs
+++ b/RuneFleet.Tests/Services/AccountManagerTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using RuneFleet.Services;
+
+namespace RuneFleet.Tests.Services
+{
+    public class AccountManagerTests
+    {
+        [Fact]
+        public void LoadAndGroupRetrieval_Works()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempFile,
+                    "JX_ACCESS_TOKEN,JX_REFRESH_TOKEN,JX_SESSION_ID,JX_DISPLAY_NAME,JX_CHARACTER_ID,Group,Client,Arguments\n" +
+                    "atk1,ref1,sid1,display1,char1,g1;g2,client1,args1\n" +
+                    "atk2,ref2,sid2,display2,char2,g2,client2,args2\n");
+
+                var manager = new AccountManager();
+                manager.Load(tempFile);
+
+                Assert.Equal(2, manager.Accounts.Count);
+                var groups = manager.GetGroups().ToList();
+                Assert.Contains("g1", groups);
+                Assert.Contains("g2", groups);
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
+        }
+    }
+}
+

--- a/RuneFleet/Services/AccountManager.cs
+++ b/RuneFleet/Services/AccountManager.cs
@@ -1,0 +1,40 @@
+using RuneFleet.Models;
+
+namespace RuneFleet.Services
+{
+    /// <summary>
+    /// Provides basic account management operations for the UI.
+    /// </summary>
+    internal class AccountManager
+    {
+        public List<Account> Accounts { get; private set; } = new();
+
+        public void Load(string path)
+        {
+            Accounts = AccountLoader.LoadFromCsv(path);
+        }
+
+        public IEnumerable<string> GetGroups()
+        {
+            return Accounts
+                .Where(a => a.Group != null)
+                .SelectMany(a => a.Group!)
+                .Where(g => !string.IsNullOrWhiteSpace(g))
+                .Distinct();
+        }
+
+        public IEnumerable<Account> GetAccounts(string? group)
+        {
+            group ??= "All";
+            return group == "All"
+                ? Accounts
+                : Accounts.Where(a => a.Group != null && a.Group.Contains(group));
+        }
+
+        public Account? GetAccountByDisplayName(string displayName)
+        {
+            return Accounts.FirstOrDefault(a => a.DisplayName == displayName);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- improve MainForm maintainability by introducing AccountManager
- update MainForm to delegate account logic to AccountManager
- add new AccountManager unit tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2994f328832389a70354f5cf4667