### PR TITLE
Dispose thumbnails on close

### DIFF
--- a/RuneFleet/MainForm.cs
+++ b/RuneFleet/MainForm.cs
@@ -45,6 +45,8 @@ namespace RuneFleet
             NativeMethods.UnregisterHotKey(this.Handle, HOTKEY_ID_PGDN);
             NativeMethods.UnregisterHotKey(this.Handle, HOTKEY_ID_PGUP);
             NativeMethods.UnregisterHotKey(this.Handle, HOTKEY_ID_DEL);
+
+            clientService.Dispose();
         }
 
         // Modifies visible account list based on group

--- a/RuneFleet/Services/ClientProcessService.cs
+++ b/RuneFleet/Services/ClientProcessService.cs
@@ -14,7 +14,7 @@ namespace RuneFleet.Services
     /// Provides client process operations such as launching, focusing,
     /// thumbnail management and environment capture.
     /// </summary>
-    internal class ClientProcessService
+internal class ClientProcessService : IDisposable
     {
         private readonly Form form;
         private readonly FlowLayoutPanel panel;
@@ -421,6 +421,11 @@ namespace RuneFleet.Services
                 throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to read pointer.");
 
             return new IntPtr(BitConverter.ToInt32(buffer, 0));
+        }
+
+        public void Dispose()
+        {
+            CleanupThumbnailsAndControls();
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up thumbnails on disposing `ClientProcessService`
- invoke `Dispose()` from `MainForm` closing event

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2fd6f8848323a91242112ddac12d