### PR TITLE
Improve exception logging

### DIFF
--- a/RuneFleet/Services/ClientProcessService.cs
+++ b/RuneFleet/Services/ClientProcessService.cs
@@ -81,7 +81,7 @@ namespace RuneFleet.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine("FocusClient: " + ex);
+                Trace.TraceError($"FocusClient failed: {ex}");
             }
         }
 
@@ -107,8 +107,9 @@ namespace RuneFleet.Services
                         continue;
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Trace.TraceWarning($"Unable to read process {acc.Pid}: {ex.Message}");
                     acc.Pid = null;
                     continue;
                 }
@@ -170,7 +171,10 @@ namespace RuneFleet.Services
                     {
                         proc.Kill();
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError($"Failed to kill process {proc.Id}: {ex.Message}");
+                    }
                     acc.Pid = null;
                     RefreshProcessDisplay();
                     refreshListView();
@@ -248,7 +252,10 @@ namespace RuneFleet.Services
                             File.AppendAllText("accounts.csv", $"{acc.AccessToken},{acc.RefreshToken},{acc.SessionId},{acc.DisplayName},{acc.CharacterId},Captured;,{acc.Client},{acc.Arguments}\r\n");
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError($"Failed to capture process {proc.Id}: {ex}");
+                    }
                 }
                 await Task.Delay(2000, token);
             }
@@ -284,7 +291,10 @@ namespace RuneFleet.Services
                     if (!childProc.HasExited)
                         return childPid;
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning($"Failed to inspect child process {childPid}: {ex.Message}");
+                }
             }
             return null;
         }


### PR DESCRIPTION
## Summary
- replace empty catch blocks with Trace logging in `ClientProcessService`
- use Trace for error reporting instead of `Console.WriteLine`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2fcb7e6483238ef5564c6aae8171