### PR TITLE
Update thumbnails when panel layout changes

### DIFF
--- a/RuneFleet/MainForm.cs
+++ b/RuneFleet/MainForm.cs
@@ -33,6 +33,9 @@ namespace RuneFleet
                 accountManager.Accounts,
                 () => UpdateListView(groupSelection.SelectedItem?.ToString() ?? "All"));
 
+            flowPanelProcesses.Scroll += flowPanelProcesses_Scroll;
+            flowPanelProcesses.Resize += flowPanelProcesses_Resize;
+
             // Handling the keybinds
             NativeMethods.RegisterHotKey(this.Handle, HOTKEY_ID_PGDN, 0, (uint)Keys.PageDown);
             NativeMethods.RegisterHotKey(this.Handle, HOTKEY_ID_PGUP, 0, (uint)Keys.PageUp);
@@ -216,6 +219,16 @@ namespace RuneFleet
             {
                 MainForm.ActiveForm.TopMost = false;
             }
+        }
+
+        private void flowPanelProcesses_Scroll(object sender, ScrollEventArgs e)
+        {
+            clientService.UpdateThumbnailPositions();
+        }
+
+        private void flowPanelProcesses_Resize(object sender, EventArgs e)
+        {
+            clientService.UpdateThumbnailPositions();
         }
     }
 

--- a/RuneFleet/Services/ClientProcessService.cs
+++ b/RuneFleet/Services/ClientProcessService.cs
@@ -21,6 +21,7 @@ namespace RuneFleet.Services
         private readonly List<Account> accounts;
         private readonly Action refreshListView;
         private readonly Dictionary<IntPtr, IntPtr> thumbnailMap = new();
+        private readonly Dictionary<IntPtr, PictureBox> pictureMap = new();
 
         public ClientProcessService(Form form,
                                     FlowLayoutPanel panel,
@@ -123,6 +124,7 @@ namespace RuneFleet.Services
                 NativeMethods.DwmUnregisterThumbnail(thumb);
 
             thumbnailMap.Clear();
+            pictureMap.Clear();
             panel.Controls.Clear();
         }
 
@@ -145,6 +147,7 @@ namespace RuneFleet.Services
             {
                 SetThumbnailProperties(pictureBox, thumb);
                 thumbnailMap[hwnd] = thumb;
+                pictureMap[hwnd] = pictureBox;
             }
         }
 
@@ -200,6 +203,17 @@ namespace RuneFleet.Services
             };
 
             NativeMethods.DwmUpdateThumbnailProperties(thumb, ref props);
+        }
+
+        public void UpdateThumbnailPositions()
+        {
+            foreach (var kvp in thumbnailMap)
+            {
+                if (pictureMap.TryGetValue(kvp.Key, out var box))
+                {
+                    SetThumbnailProperties(box, kvp.Value);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- refresh DWM thumbnail rectangles whenever the process panel is scrolled or resized
- track thumbnails' picture boxes so rectangles can be updated

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2fe4bbb88323960388157ceb1ad8