### PR TITLE
Add borderless toggle for game clients

### DIFF
--- a/RuneFleet/Interop/NativeMethods.cs
+++ b/RuneFleet/Interop/NativeMethods.cs
@@ -19,6 +19,23 @@ namespace RuneFleet.Interop
         [DllImport("user32.dll")]
         public static extern bool ShowWindow(nint hWnd, int nCmdShow);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern long GetWindowLong(nint hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern long SetWindowLong(nint hWnd, int nIndex, long dwNewLong);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+        public const int GWL_STYLE = -16;
+        public const uint WS_CAPTION = 0x00C00000;
+        public const uint WS_THICKFRAME = 0x00040000;
+        public const uint SWP_NOSIZE = 0x0001;
+        public const uint SWP_NOMOVE = 0x0002;
+        public const uint SWP_NOZORDER = 0x0004;
+        public const uint SWP_FRAMECHANGED = 0x0020;
+
         [DllImport("dwmapi.dll")]
         public static extern int DwmRegisterThumbnail(nint dest, nint src, out nint thumb);
 

--- a/RuneFleet/MainForm.Designer.cs
+++ b/RuneFleet/MainForm.Designer.cs
@@ -40,6 +40,8 @@
             toolStripButtonScale = new ToolStripButton();
             toolStripSeparator4 = new ToolStripSeparator();
             toolStripButtonHelp = new ToolStripButton();
+            toolStripSeparator9 = new ToolStripSeparator();
+            toolStripButtonBorderless = new ToolStripButton();
             toolStripSeparator7 = new ToolStripSeparator();
             columnHeaderId = new ColumnHeader();
             ((System.ComponentModel.ISupportInitialize)numericClientScale).BeginInit();
@@ -121,7 +123,7 @@
             // toolStrip1
             // 
             toolStrip1.GripStyle = ToolStripGripStyle.Hidden;
-            toolStrip1.Items.AddRange(new ToolStripItem[] { toolStripSeparator6, toolStripButtonTop, toolStripSeparator8, toolStripButtonHot, toolStripSeparator5, toolStripButtonImport, toolStripProgressBar1, toolStripSeparator1, toolStripButtonLaunch, toolStripSeparator2, toolStripButtonRefresh, toolStripSeparator3, toolStripButtonScale, toolStripSeparator4, toolStripButtonHelp, toolStripSeparator7 });
+            toolStrip1.Items.AddRange(new ToolStripItem[] { toolStripSeparator6, toolStripButtonTop, toolStripSeparator8, toolStripButtonHot, toolStripSeparator5, toolStripButtonImport, toolStripProgressBar1, toolStripSeparator1, toolStripButtonLaunch, toolStripSeparator2, toolStripButtonRefresh, toolStripSeparator3, toolStripButtonScale, toolStripSeparator4, toolStripButtonHelp, toolStripSeparator9, toolStripButtonBorderless, toolStripSeparator7 });
             toolStrip1.Location = new Point(0, 0);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.Size = new Size(634, 25);
@@ -257,9 +259,26 @@
             toolStripButtonHelp.Text = "Help";
             toolStripButtonHelp.ToolTipText = "Displays credits and assistance info.";
             toolStripButtonHelp.Click += toolStripButtonHelp_Click;
-            // 
+            //
+            // toolStripSeparator9
+            //
+            toolStripSeparator9.Name = "toolStripSeparator9";
+            toolStripSeparator9.Size = new Size(6, 25);
+            //
+            // toolStripButtonBorderless
+            //
+            toolStripButtonBorderless.CheckOnClick = true;
+            toolStripButtonBorderless.DisplayStyle = ToolStripItemDisplayStyle.Text;
+            toolStripButtonBorderless.ImageTransparentColor = Color.Magenta;
+            toolStripButtonBorderless.Margin = new Padding(0, 1, 0, 1);
+            toolStripButtonBorderless.Name = "toolStripButtonBorderless";
+            toolStripButtonBorderless.Size = new Size(72, 23);
+            toolStripButtonBorderless.Text = "Borderless";
+            toolStripButtonBorderless.ToolTipText = "Toggle borderless mode for clients.";
+            toolStripButtonBorderless.Click += toolStripButtonBorderless_Click;
+            //
             // toolStripSeparator7
-            // 
+            //
             toolStripSeparator7.Name = "toolStripSeparator7";
             toolStripSeparator7.Size = new Size(6, 25);
             // 
@@ -304,6 +323,8 @@
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripButton toolStripButtonTop;
         private ToolStripButton toolStripButtonHelp;
+        private ToolStripSeparator toolStripSeparator9;
+        private ToolStripButton toolStripButtonBorderless;
         private ToolStripSeparator toolStripSeparator5;
         private ToolStripSeparator toolStripSeparator4;
         private ToolStripSeparator toolStripSeparator6;

--- a/RuneFleet/MainForm.cs
+++ b/RuneFleet/MainForm.cs
@@ -309,6 +309,12 @@ namespace RuneFleet
                 NativeMethods.UnregisterHotKey(this.Handle, HOTKEY_ID_DEL);
             }
         }
+
+        private void toolStripButtonBorderless_Click(object sender, EventArgs e)
+        {
+            clientService.BorderlessEnabled = toolStripButtonBorderless.Checked;
+            clientService.ApplyBorderlessToAll();
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- add win32 methods for adjusting window styles
- implement borderless mode in `ClientProcessService`
- add toolbar button to toggle borderless mode

## Testing
- `dotnet test --no-build` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_688d49458e788323a782707924760ee1