### PR TITLE
Add right-click account editing dialog

### DIFF
--- a/RuneFleet/EditAccountForm.cs
+++ b/RuneFleet/EditAccountForm.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using RuneFleet.Models;
+
+namespace RuneFleet
+{
+    internal class EditAccountForm : Form
+    {
+        private readonly Account account;
+        private TextBox txtDisplayName;
+        private TextBox txtGroup;
+        private TextBox txtClient;
+        private TextBox txtArguments;
+        private Button btnSave;
+        private Button btnCancel;
+
+        public EditAccountForm(Account account)
+        {
+            this.account = account;
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            this.Text = "Edit Account";
+            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.StartPosition = FormStartPosition.CenterParent;
+            this.ClientSize = new Size(400, 170);
+
+            Label lblDisplayName = new Label() { Text = "Display Name", Left = 10, Top = 15, AutoSize = true };
+            txtDisplayName = new TextBox() { Left = 110, Top = 12, Width = 270, Text = account.DisplayName ?? string.Empty };
+
+            Label lblGroup = new Label() { Text = "Group", Left = 10, Top = 45, AutoSize = true };
+            txtGroup = new TextBox() { Left = 110, Top = 42, Width = 270, Text = account.Group != null ? string.Join(";", account.Group) : string.Empty };
+
+            Label lblClient = new Label() { Text = "Client", Left = 10, Top = 75, AutoSize = true };
+            txtClient = new TextBox() { Left = 110, Top = 72, Width = 270, Text = account.Client ?? string.Empty };
+
+            Label lblArguments = new Label() { Text = "Arguments", Left = 10, Top = 105, AutoSize = true };
+            txtArguments = new TextBox() { Left = 110, Top = 102, Width = 270, Text = account.Arguments ?? string.Empty };
+
+            btnSave = new Button() { Text = "Save", Left = 224, Width = 75, Top = 130, DialogResult = DialogResult.None };
+            btnSave.Click += btnSave_Click;
+            btnCancel = new Button() { Text = "Cancel", Left = 305, Width = 75, Top = 130, DialogResult = DialogResult.Cancel };
+
+            this.Controls.AddRange(new Control[] { lblDisplayName, txtDisplayName, lblGroup, txtGroup, lblClient, txtClient, lblArguments, txtArguments, btnSave, btnCancel });
+            this.AcceptButton = btnSave;
+            this.CancelButton = btnCancel;
+        }
+
+        private void btnSave_Click(object? sender, EventArgs e)
+        {
+            var clientPath = txtClient.Text.Trim();
+            if (!string.IsNullOrWhiteSpace(clientPath) && !File.Exists(clientPath))
+            {
+                MessageBox.Show("Client path does not exist.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var groupText = txtGroup.Text.Trim();
+            if (groupText.Contains(','))
+            {
+                MessageBox.Show("Groups must be separated using ';'.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            account.DisplayName = txtDisplayName.Text.Trim();
+            account.Group = groupText.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            account.Client = clientPath;
+            account.Arguments = txtArguments.Text.Trim();
+
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+    }
+}

--- a/RuneFleet/MainForm.Designer.cs
+++ b/RuneFleet/MainForm.Designer.cs
@@ -7,6 +7,8 @@
         private System.Windows.Forms.ColumnHeader columnHeaderDisplayName;
         private System.Windows.Forms.ColumnHeader columnHeaderPID;
         private System.Windows.Forms.FlowLayoutPanel flowPanelProcesses;
+        private System.Windows.Forms.ContextMenuStrip contextMenuAccounts;
+        private System.Windows.Forms.ToolStripMenuItem editAccountToolStripMenuItem;
 
         protected override void Dispose(bool disposing)
         {
@@ -22,6 +24,8 @@
             columnHeaderPID = new ColumnHeader();
             columnHeaderId = new ColumnHeader();
             flowPanelProcesses = new FlowLayoutPanel();
+            contextMenuAccounts = new ContextMenuStrip(components);
+            editAccountToolStripMenuItem = new ToolStripMenuItem();
             groupSelection = new ComboBox();
             labelLoading = new Label();
             numericClientScale = new NumericUpDown();
@@ -49,7 +53,7 @@
             SuspendLayout();
             // 
             // listViewAccounts
-            // 
+            //
             listViewAccounts.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             listViewAccounts.Columns.AddRange(new ColumnHeader[] { columnHeaderDisplayName, columnHeaderPID, columnHeaderId });
             listViewAccounts.FullRowSelect = true;
@@ -63,6 +67,21 @@
             listViewAccounts.ItemActivate += listViewAccounts_ItemActivate;
             listViewAccounts.Click += listViewAccounts_ItemActivate;
             listViewAccounts.DoubleClick += buttonLaunchSelected_Click;
+            listViewAccounts.ContextMenuStrip = contextMenuAccounts;
+            listViewAccounts.MouseDown += listViewAccounts_MouseDown;
+
+            // contextMenuAccounts
+            //
+            contextMenuAccounts.Items.AddRange(new ToolStripItem[] { editAccountToolStripMenuItem });
+            contextMenuAccounts.Name = "contextMenuAccounts";
+            contextMenuAccounts.Size = new Size(181, 48);
+
+            // editAccountToolStripMenuItem
+            //
+            editAccountToolStripMenuItem.Name = "editAccountToolStripMenuItem";
+            editAccountToolStripMenuItem.Size = new Size(180, 22);
+            editAccountToolStripMenuItem.Text = "Edit Account";
+            editAccountToolStripMenuItem.Click += editAccountToolStripMenuItem_Click;
             // 
             // columnHeaderDisplayName
             // 

--- a/RuneFleet/MainForm.cs
+++ b/RuneFleet/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using RuneFleet.Interop;
 using RuneFleet.Services;
+using RuneFleet.Models;
 using System.Windows.Forms;
 
 namespace RuneFleet
@@ -80,6 +81,7 @@ namespace RuneFleet
                 var item = new ListViewItem(acc.DisplayName);
                 item.SubItems.Add(acc.Pid?.ToString() ?? "");
                 item.SubItems.Add(acc.CharacterId?.ToString() ?? "");
+                item.Tag = acc;
                 if (group == "All" || (acc.Group != null && acc.Group.Contains(group)))
                 {
                     listViewAccounts.Items.Add(item);
@@ -131,6 +133,38 @@ namespace RuneFleet
                 }
             }
             UpdateListView(groupSelection.SelectedItem?.ToString() ?? "All");
+        }
+
+        private void listViewAccounts_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                var item = listViewAccounts.GetItemAt(e.X, e.Y);
+                if (item != null)
+                {
+                    listViewAccounts.SelectedItems.Clear();
+                    item.Selected = true;
+                }
+            }
+        }
+
+        private void editAccountToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (listViewAccounts.SelectedItems.Count == 0) return;
+            if (listViewAccounts.SelectedItems[0].Tag is not Account acc) return;
+            using var editForm = new EditAccountForm(acc);
+            if (editForm.ShowDialog(this) == DialogResult.OK)
+            {
+                var pids = accountManager.Accounts.Select(a => a.Pid).ToList();
+                accountManager.Save("accounts.csv");
+                accountManager.Load("accounts.csv");
+                for (int i = 0; i < accountManager.Accounts.Count && i < pids.Count; i++)
+                {
+                    accountManager.Accounts[i].Pid = pids[i];
+                }
+                UpdateGroupView();
+                UpdateListView(groupSelection.SelectedItem?.ToString() ?? "All");
+            }
         }
 
 

--- a/RuneFleet/Services/AccountManager.cs
+++ b/RuneFleet/Services/AccountManager.cs
@@ -18,6 +18,15 @@ namespace RuneFleet.Services
             Accounts = LoadFromCsv(path);
         }
 
+        public void Save(string path)
+        {
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture);
+            using var writer = new StreamWriter(path);
+            using var csv = new CsvWriter(writer, config);
+            csv.Context.RegisterClassMap<AccountMap>();
+            csv.WriteRecords(Accounts);
+        }
+
         private static List<Account> LoadFromCsv(string path)
         {
             try


### PR DESCRIPTION
## Summary
- allow editing accounts via right-click context menu
- validate client path and group separator
- persist account changes back to CSV and refresh UI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b2e66b08323a457f70f763e6909